### PR TITLE
Fix for ERR_PACKET_LENGTH_MISMATCH rcvd

### DIFF
--- a/src/mariadb_connector.cpp
+++ b/src/mariadb_connector.cpp
@@ -932,14 +932,6 @@ TypedArray<Dictionary> MariaDBConnector::_parse_string_rows(PackedByteArray &p_r
 					return TypedArray<Dictionary>();
 				}
 
-				len_encode = _decode_lenenc_adv_itr(p_rx_bfr, p_pkt_idx);
-				_last_error = _rcv_bfr_chk(p_rx_bfr, bfr_size, p_pkt_idx, len_encode);
-				if (_last_error != OK) {
-					ERR_PRINT(
-							vformat("ERR_PACKET_LENGTH_MISMATCH rcvd %d expect %d", bfr_size, p_pkt_idx + len_encode));
-					return TypedArray<Dictionary>();
-				}
-
 				if (field_len > 0) {
 					PackedByteArray data = _get_pkt_bytes_adv_idx(p_rx_bfr, p_pkt_idx, field_len);
 					dict[field_name] = _get_type_data(field_type, data);


### PR DESCRIPTION
I added a column in my DB for VARBINARY(256) for opaque_record for auth. After doing so I no longer could select all of my rows using 'SELECT * FROM accounts;'

I got this error:

```
ERR_PACKET_LENGTH_MISMATCH rcvd 941 expect 1146
  <C++ Source>  src/mariadb_connector.cpp:909 @ _parse_string_rows()
  <Stack Trace> DB.gd:30 @ iterate_all()
                Model.gd:88 @ pull_table()
                MMOServer.gd:12 @ init()
                Client.gd:22 @ _connected()ne seemed to work. 
```

The mismatch numbers would change based off what mysql type I used. None seemed to work. had to fix the code. The marker was not moving right after 250 characters.

I also had to make a lot of changes to this file and a couple of others in order to get it to compile. I left out those changes as they were just compile errors, and not logical errors.

https://github.com/sigrudds1/godot-mariadb-connector-plugin/issues/6